### PR TITLE
Fix image list index out of range

### DIFF
--- a/dockup/dockup.go
+++ b/dockup/dockup.go
@@ -27,18 +27,28 @@ func ListImages() []Images {
 	}
 	defer cli.Close()
 
-	tmp := []Images{{}}
+	tmp := []Images{}
 
 	listImage, err := cli.ImageList(ctx, image.ListOptions{})
 
 	if err != nil {
 		panic(err)
 	}
+
 	for index, l := range listImage {
-		if index == 0 {
-			tmp[index] = Images{Id: index, Name: l.RepoTags[0], Digest: l.ID}
+
+		if len(l.RepoTags) > 0 {
+			tmp = append(tmp, Images{
+				Id:     index,
+				Name:   l.RepoTags[0],
+				Digest: l.ID},
+			)
 		} else {
-			tmp = append(tmp, Images{Id: index, Name: l.RepoTags[0], Digest: l.ID})
+			tmp = append(tmp, Images{
+				Id:     index,
+				Name:   l.ID,
+				Digest: l.ID},
+			)
 		}
 	}
 	return tmp

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 
 func main() {
 
-	//var selectedList []string
 	var confirm bool
 	var selectedList []string
 	var bindings string
@@ -18,7 +17,6 @@ func main() {
 
 	form := huh.NewForm(
 		huh.NewGroup(
-
 			huh.NewMultiSelect[string]().
 				Title("Choice a image to updade").
 				OptionsFunc(func() []huh.Option[string] {
@@ -30,7 +28,6 @@ func main() {
 				}, bindings).
 				Value(&selectedList),
 		),
-
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Do you want to restart the containers that use the selected images?").


### PR DESCRIPTION
- Adds a check for empty `RepoTags` before accessing
- Uses the image ID as a fallback name when no tags are present
- Removes the initial empty element from the `tmp` slice to ensure correct indexing